### PR TITLE
Edge labels [on] and Force Labels [on  - after assignment]

### DIFF
--- a/src/compas_ags/rhino/formobject.py
+++ b/src/compas_ags/rhino/formobject.py
@@ -17,10 +17,10 @@ class FormObject(DiagramObject):
         'show.edges': True,
         'show.faces': False,
         'show.vertexlabels': False,
-        'show.edgelabels': False,
+        'show.edgelabels': True,
         'show.facelabels': False,
         'show.forcecolors': True,
-        'show.forcelabels': True,
+        'show.forcelabels': False,
         'show.forcepipes': True,
 
         'color.vertices': (0, 0, 0),

--- a/ui/Rhino/AGS/dev/AGS_form_assign_forces_cmd.py
+++ b/ui/Rhino/AGS/dev/AGS_form_assign_forces_cmd.py
@@ -52,7 +52,11 @@ Please select the independent edges first.""")
                 form.diagram.edge_attribute(edge, 'f', F)
                 form.diagram.edge_attribute(edge, 'q', Q)
 
+        form.settings['show.forcelabels'] = True
+        form.settings['show.edgelabels'] = False
+        scene.update()
         scene.save()
+
 
 
 # ==============================================================================


### PR DESCRIPTION
This turn edge_label on as default.

It also switches to show_forces on after assignment of forces is made. 

This way user can know the edges in which they intend to apply forces.